### PR TITLE
chore: check http is present in image route

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
   const customFetcher = async (url: string) => {
      const response = await fetch(
-       `http://127.0.0.1:3001/api/proxyLinkPreview/?url=${url}`
+       `http://127.0.0.1:3001/api/link-preview/?url=${url}`
      );
      const json = await response.json();
      console.warn(json.metadata);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,28 @@
 {
   "name": "leleka-backend",
   "version": "1.0.0",
+  "authors": [
+    {
+      "name": "Alexandr Tovmach",
+      "email": "alexandrtovmach@gmail.com"
+    },
+    {
+      "name": "Vitalii Denysyuk",
+      "email": "denvit1@gmail.com"
+    },
+    {
+      "name": "Maksim Fomin",
+      "email": "fomin.max.13@gmail.com"
+    },
+    {
+      "name": "Andrew Kaenko",
+      "email": "kaenkoa@gmail.com"
+    },
+    {
+      "name": "Paukov Nikita",
+      "email": "nikpaukov8214@gmail.com"
+    }
+  ],
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -13,7 +35,6 @@
     "lint-staged": "lint-staged"
   },
   "keywords": [],
-  "author": "",
   "license": "ISC",
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/src/services/proxyLinkPreview.service.ts
+++ b/src/services/proxyLinkPreview.service.ts
@@ -29,6 +29,11 @@ export const getMetadata = async (url: string): Promise<APIOutput> => {
     output.image = images[0];
   }
 
+  if (output.image && output.image.startsWith("/")) {
+    output.image =
+      (url.endsWith("/") ? url.slice(0, url.length - 1) : url) + output.image;
+  }
+
   output.description = og.description || meta.description || "";
   output.title = og.title || meta.title || "";
   output.siteName = og.site_name || "";


### PR DESCRIPTION
check that "http" is present in the image route in the link preview route. Some links gave back not absolute routes to images